### PR TITLE
Remoção de setas e alteração cabeçalho

### DIFF
--- a/aproveitamento.html
+++ b/aproveitamento.html
@@ -152,14 +152,14 @@
                 <p class="text-center wow fadeInDown"> 	Para isso, é preciso solicitar o aproveitamento de estudos no Colegiado da Elétrica.  A coordenação vai avaliar a equivalência entre o programa das disciplinas que você já fez  (conteúdo e carga horária) com alguma disciplina existente na UFMG. Se estiver tudo certo, você será dispensado. </p>
 
                 <div style="padding-top: 40px;">
-                <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Datas e local da solicitação </h3></p>
+                <p><h3 class="media-heading">Datas e local da solicitação </h3></p>
                   <p>	 O prazo para protocolar a solicitação de aproveitamento de estudos é estipulado no Calendário Acadêmico da UFMG e a solicitação deve ser feita no Colegiado do Curso. </p>
                 </div>
 
 
 
                 <div style="padding-top: 40px;">
-                  <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Outras informações</h3></p>
+                  <p><h3 class="media-heading">Outras informações</h3></p>
                   <p>Quando o resultado do aproveitamento sair, será registrado no sistema acadêmico as disciplinas que foram dispensadas. Caso seu pedido não seja aceito, o Colegiado vai te mandar um email informando o indeferimento. </p>
                   <p>É sugerido que se o aluno estiver matriculado na disciplina em que pediu dispensa, frequente as aulas até que obtenha resposta do processo. Caso isso não aconteça e o aproveitamento de estudos não seja aprovado, o aluno pode ser reprovado na disciplina. </p>
                   <p>Outra coisa é que as notas das atividades dispensadas não serão consideradas para o cálculo de RSG. </p>
@@ -168,7 +168,7 @@
 
 
                 <div style="padding-top: 40px;">
-                  <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Documentação </h3></p>
+                  <p><h3 class="media-heading">Documentação </h3></p>
                   <ul>
                     <li>Programa completo da disciplina a qual se deseja dispensar </li>
                     <li>Histórico escolar </li>

--- a/atividades_extracurriculares.html
+++ b/atividades_extracurriculares.html
@@ -149,7 +149,7 @@
 
             <div style="padding-top: 60px;">
               <h2 class="column-title"> Empresas Juniores </h2>
-              <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> CPE Jr</h3></p>
+              <p><h3 class="media-heading">CPE Jr</h3></p>
               <p><img src="imagens/atividades/manual/atividades_extracurriculares/cpejr.png" style="float:left;padding-bottom: 15px; padding-top: 15px;padding-right: 15px;"></p>
               <p>
                 Procurando prover uma experiência diferenciada de contato com o mercado e com o empreendedorismo ainda na faculdade, a CPE Jr. é uma empresa júnior
@@ -164,7 +164,7 @@
             </div>
 
             <div style="padding-top: 60px;">
-              <h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Núcleo UFMG Jr</h3>
+              <h3 class="media-heading">Núcleo UFMG Jr</h3>
               <p><img src="imagens/atividades/manual/atividades_extracurriculares/nucleojr.png" style="float:left;padding-bottom: 15px; padding-top: 15px;padding-right: 15px;"></p>
               <p>
                 O Núcleo UFMG Júnior é uma instância do MEJ - Movimento Empresa Junior -
@@ -186,7 +186,7 @@
 
             <div style="padding-top: 60px;">
               <h2 class="column-title">Movimento Estudantil</h2>
-              <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Grêmio de Estudantes de Engenharia Elétrica</h3></p>
+              <p><h3 class="media-heading">Grêmio de Estudantes de Engenharia Elétrica</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/gremio.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 O GEEE, ou G3E, é uma associação civil sem fins lucrativos e é a entidade
@@ -205,7 +205,7 @@
             </div>
 
              <div style="padding-top: 60px;">
-              <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Diretório Acadêmico da Escola de Engenharia</h3></p>
+              <p><h3 class="media-heading">Diretório Acadêmico da Escola de Engenharia</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/da.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 400px;"></p>
               <p>
                 Fundado em 11 de dezembro de 1914, o Diretório Acadêmico da Escola de
@@ -223,7 +223,7 @@
 
             <div style="padding-top: 60px;">
               <h2 class="column-title">Associações</h2>
-              <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Coral da Escola de Engenharia</h3></p>
+              <p><h3 class="media-heading">Coral da Escola de Engenharia</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/coral.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 O Coral da Escola de Engenharia, que nasceu de uma em parceria com o
@@ -238,7 +238,7 @@
             </div>
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Associação Atlética Acadêmica da Escola de Engenharia</h3></p>
+             <p><h3 class="media-heading">Associação Atlética Acadêmica da Escola de Engenharia</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/atletica.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 A Associação Atlética da Escola de Engenharia da UFMG foi fundada em 1949
@@ -257,7 +257,7 @@
             </div>
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Bateria Engrenada</h3></p>
+             <p><h3 class="media-heading">Bateria Engrenada</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/engrenada.jpg" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 Bateria universitária da Associação Atlética da Escola de Engenharia da UFMG, formada por estudantes da própria escola.</p>
@@ -268,7 +268,7 @@
 
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Engenharia UFMG Cheer</h3></p>
+             <p><h3 class="media-heading">Engenharia UFMG Cheer</h3></p>
 
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/cheer.jpg" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
@@ -281,7 +281,7 @@
 
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Engenharia Solidária</h3></p>
+             <p><h3 class="media-heading">Engenharia Solidária</h3></p>
              <p><img src=" imagens/atividades/manual/atividades_extracurriculares/engenharia_solidaria.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 400px;"></p>
               <p>
                 A Engenharia Solidária é uma associação estudantil que busca
@@ -301,7 +301,7 @@
 
             <div style="padding-top: 60px;">
               <h2 class="column-title">Equipes de Competição</h2>
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Uai, sô! fly!!!</h3></p>
+             <p><h3 class="media-heading">Uai, sô! fly!!!</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/uai_so_fly.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 Composta por estudantes de graduação em Engenharia da UFMG, a equipe
@@ -321,7 +321,7 @@
 
 
             <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Autobotz UFMG</h3></p>
+             <p><h3 class="media-heading">Autobotz UFMG</h3></p>
              <p> <img src=" imagens/atividades/manual/atividades_extracurriculares/autobotz.jpg" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p style="margin:40px;">
                 Desenvolvimento e execução de projetos de pesquisa no âmbito da robótica autônoma, com ênfase no desenvolvimento de robôs a serem utilizados em competições de cunho nacional e internacional.</p>
@@ -331,7 +331,7 @@
             </div>
 
             <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Fórmula SAE UFMG</h3></p>
+             <p><h3 class="media-heading">Fórmula SAE UFMG</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/formula.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px;"></p>
               <p>
                 O Fórmula SAE UFMG é é uma equipe de competição composta por
@@ -350,7 +350,7 @@
             </div>
 
             <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Fórmula Tesla UFMG</h3></p>
+             <p><h3 class="media-heading">Fórmula Tesla UFMG</h3></p>
              <p> <img src=" imagens/atividades/manual/atividades_extracurriculares/tesla.jpg" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 A equipe Fórmula Tesla UFMG desenvolve tecnologia automotiva focada em
@@ -370,7 +370,7 @@
 
 
             <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Baja UFMG</h3></p>
+             <p><h3 class="media-heading">Baja UFMG</h3></p>
               <p><img src=" imagens/atividades/manual/atividades_extracurriculares/baja.png" style="float:left;padding-bottom: 15px; padding-top: 15px;padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 O Baja UFMG é uma equipe composta exclusivamente por estudantes de
@@ -392,7 +392,7 @@
 
 
             <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Milhagem UFMG</h3></p>
+             <p><h3 class="media-heading">Milhagem UFMG</h3></p>
              <p><img src=" imagens/atividades/manual/atividades_extracurriculares/milhagem.jpg" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 A Equipe Milhagem UFMG é um projeto extracurricular, composto por alunos
@@ -414,7 +414,7 @@
 
             <div style="padding-top: 60px;">
               <h2 class="column-title">Projetos de Extensão</h2>
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> ENG200</h3></p>
+             <p><h3 class="media-heading">ENG200</h3></p>
             <p><img src=" imagens/atividades/manual/atividades_extracurriculares/eng200.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 Com o intuito de prover um ensino de excelência e condizente com os desafios
@@ -435,7 +435,7 @@
             </div>
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Selex</h3></p>
+             <p><h3 class="media-heading">Selex</h3></p>
              <p><img src=" imagens/atividades/manual/atividades_extracurriculares/selex.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 400px;"></p>
               <p>
                 O Sistemas Elétricos Experimentais (SELEX) é um projeto de extensão que
@@ -451,7 +451,7 @@
             </div>
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Equalizar</h3></p>
+             <p><h3 class="media-heading">Equalizar</h3></p>
              <p><img src=" imagens/atividades/manual/atividades_extracurriculares/equalizar.png" style="float:left;padding-bottom: 15px; padding-top: 15px; padding-right: 15px; width: 300px; height: 300px;"></p>
               <p>
                 O Equalizar é um Projeto de Extensão da UFMG que quer transformar a
@@ -471,7 +471,7 @@
             </div>
 
              <div style="padding-top: 60px;">
-             <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> CIPMOI</h3></p>
+             <p><h3 class="media-heading">CIPMOI</h3></p>
              <p><img src=" imagens/atividades/manual/atividades_extracurriculares/cipmoi.png" style="float:left;padding-bottom: 15px; padding-top: 15px;padding-right: 15px;"></p>
               <p>
                 O Curso Intensivo de Preparação de Mão de Obra Industrial (CIPIMOI) tem

--- a/comprovacaoconhecimento.html
+++ b/comprovacaoconhecimento.html
@@ -111,7 +111,7 @@
                      <li class="scroll active"><a href="disciplinas.html">Disciplinas</a></li>
                          <li class="scroll active"><a href="atividades_extracurriculares.html">Atividades Extracurriculares</a></li>
                          <li class="scroll active"><a href="certificados.html">Certificados</a></li>
-                         <li class="scroll active"><a href="atividades_academicas.html">Atividades Acadêmicas</a></li>
+                         <li class="scroll active"><a href="matricula.html">Matrícula</a></li>
                          <li class="scroll active"><a href="comprovacaoconhecimento.html">Comprovação de Estudos</a></li>
                     </ul>
                <!-- </div>
@@ -146,7 +146,7 @@
 				        <p class="text-center wow fadeInDown">Existe um exame que tem como objetivo comprovar se o  aluno possui o conhecimento devido para dispensar o curso de uma disciplina. Assim, se você julgar que já tem todo o conhecimento ministrado por alguma matéria e não quer cursá-la, pode requerer junto ao Colegiado o exame de comprovação de conhecimento. </p>
 
                 <div style="padding-top: 60px;">
-                  <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> O aluno só poderá solicitar a comprovação de conhecimento se:</h3></p>
+                  <p><h3 class="media-heading">O aluno só poderá solicitar a comprovação de conhecimento se:</h3></p>
                   <ul>
                     <li> Estiver regularmente matriculado no Curso de Graduação da UFMG (não afastado para intercâmbio, sem trancamento total).</li>
                     <li> Não ter requerido exame de comprovação de conhecimento na disciplina anteriormente.</li>
@@ -156,7 +156,7 @@
                 </div>
 
                 <div style="padding-top: 30px;">
-                  <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Quando e onde solicitar</h3></p>
+                  <p><h3 class="media-heading">Quando e onde solicitar</h3></p>
                   <ul>
                     <li>O pedido da avaliação deve ser feito nos primeiros 15 (quinze) dias contados a partir do primeiro dia letivo do semestre, devendo ser feito junto ao Colegiado do curso. A aplicação da prova e divulgação do resultado pode levar muito tempo.</li>
                     <li>Dessa maneira, o aluno solicitará ao Colegiado um requerimento com o seu pedido e a partir dele a coordenação do curso formará uma banca de 3 professores pertencentes ao departamento da disciplina para elaborar e aplicar o exame ao estudante. O departamento fixará a data, o local da prova e o conteúdo programático, sendo de responsabilidade do Colegiado informar ao aluno.</li>
@@ -164,7 +164,7 @@
                 </div>
 
                 <div style="padding-top: 30px;">
-                  <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Outras informações:</h3></p>
+                  <p><h3 class="media-heading">Outras informações:</h3></p>
                   <ul>
                     <li> O resultado do exame de comprovação de conhecimento será computado no RSG do aluno, quer seja aprovado ou não no exame.</li>
                     <li> O estudante deverá alcançar 60 pontos em um total de 100 pontos, para ser aprovado no exame.</li>

--- a/contatoprof.html
+++ b/contatoprof.html
@@ -111,7 +111,7 @@
                      <li class="scroll active"><a href="disciplinas.html">Disciplinas</a></li>
                          <li class="scroll active"><a href="atividades_extracurriculares.html">Atividades Extracurriculares</a></li>
                          <li class="scroll active"><a href="certificados.html">Certificados</a></li>
-                         <li class="scroll active"><a href="atividades_academicas.html">Atividades Acadêmicas</a></li>
+                         <li class="scroll active"><a href="matricula.html">Matrícula</a></li>
                          <li class="scroll active"><a href="comprovacaoconhecimento.html">Comprovação de Estudos</a></li>
                     </ul>
                <!-- </div>

--- a/fump.html
+++ b/fump.html
@@ -151,7 +151,7 @@
 				<p  class="text-center wow fadeInDown">	 A Fundação Universitária Mendes Pimentel (FUMP) é uma instituição controlada pela UFMG e tem como missão prestar assistência estudantil aos alunos da Universidade. Os benefícios e auxílios oferecidos pela Fump são para os estudantes de graduação de cursos presenciais da UFMG, que estejam matriculados, frequentes e que necessitem de algum apoio para se manter na Universidade.</p>
 
         <div style="padding-top: 40px;">
-          <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Assistências cedidas pela Fump</h3></p>
+          <p><h3 class="media-heading">Assistências cedidas pela Fump</h3></p>
           <ul>
             <li> Alimentação </li>
             <li> Moradia universitária</li>
@@ -164,7 +164,7 @@
         </ul>
         </div>
         <div style="padding-top: 20px;">
-          <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Como ter acesso aos benefícios da Fump?</h3></p>
+          <p><h3 class="media-heading">Como ter acesso aos benefícios da Fump?</h3></p>
           <p>Para ter acesso aos benefícios é necessário preencher um Questionário Socioeconômico, disponível em: <a href="http://sinae.fump.ufmg.br/sinaeWeb/login.jsf">http://sinae.fump.ufmg.br/sinaeWeb/login.jsf</a>
   				</p>
   				<p>Após responder o questionário, o aluno deve reunir alguns documentos específicos e levá-los à Fundação, para passar por um análise, triagem e, posteriormente uma entrevista com os assistentes da Fump.</p>
@@ -180,7 +180,7 @@
 				<p class="text-center wow fadeInDown">	O valor das refeições nos RUs varia segundo diversas categorias: </p>
 
          <div class="media-body">
-                <p><h3 class="media-heading"><span class="glyphicon glyphicon-arrow-right"></span> Tabela de preços dos RUs</h2></p><br>
+                <p><h3 class="media-heading">Tabela de preços dos RUs</h2></p><br>
                  <table class="table">
                      <thead>
                          <tr>


### PR DESCRIPTION
Removidas setas dos títulos das Atividades Extracurriculares, Comprovação de Conhecimento, Aproveitamento de Estudo, FUMP/CEU e Contato dos Professores.
Alterado cabeçalho errado nas páginas referentes à Comprovação de Conhecimento e Contato dos Professores.